### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/examples/twitter/app.py
+++ b/examples/twitter/app.py
@@ -64,8 +64,7 @@ class User(BaseModel):
         ).count() > 0
 
     def gravatar_url(self, size=80):
-        return 'http://www.gravatar.com/avatar/%s?d=identicon&s=%d' % \
-               (md5(self.email.strip().lower().encode('utf-8')).hexdigest(),
+        return 'http://www.gravatar.com/avatar/{0!s}?d=identicon&s={1:d}'.format(md5(self.email.strip().lower().encode('utf-8')).hexdigest(),
                 size)
 
 
@@ -109,7 +108,7 @@ def auth_user(user):
     session['logged_in'] = True
     session['user_id'] = user.id
     session['username'] = user.username
-    flash('You are logged in as %s' % (user.username))
+    flash('You are logged in as {0!s}'.format((user.username)))
 
 
 # get the user from the session
@@ -296,7 +295,7 @@ def user_follow(username):
     except IntegrityError:
         pass
 
-    flash('You are following %s' % user.username)
+    flash('You are following {0!s}'.format(user.username))
     return redirect(url_for('user_detail', username=user.username))
 
 
@@ -308,7 +307,7 @@ def user_unfollow(username):
         (Relationship.from_user == get_current_user()) &
         (Relationship.to_user == user)
     ).execute()
-    flash('You are no longer following %s' % user.username)
+    flash('You are no longer following {0!s}'.format(user.username))
     return redirect(url_for('user_detail', username=user.username))
 
 

--- a/src/peewee/core.py
+++ b/src/peewee/core.py
@@ -406,7 +406,7 @@ def not_allowed(func):
     """
 
     def inner(self, *args, **kwargs):
-        raise NotImplementedError('%s is not allowed on %s instances' % (
+        raise NotImplementedError('{0!s} is not allowed on {1!s} instances'.format(
             func, type(self).__name__))
 
     return inner
@@ -606,13 +606,13 @@ class Node(object):
         return Expression(self, OP.IS_NOT, None)
 
     def contains(self, rhs):
-        return Expression(self, OP.ILIKE, '%%%s%%' % rhs)
+        return Expression(self, OP.ILIKE, '%{0!s}%'.format(rhs))
 
     def startswith(self, rhs):
-        return Expression(self, OP.ILIKE, '%s%%' % rhs)
+        return Expression(self, OP.ILIKE, '{0!s}%'.format(rhs))
 
     def endswith(self, rhs):
-        return Expression(self, OP.ILIKE, '%%%s' % rhs)
+        return Expression(self, OP.ILIKE, '%{0!s}'.format(rhs))
 
     def between(self, low, high):
         return Expression(self, OP.BETWEEN, Clause(low, R('AND'), high))
@@ -789,7 +789,7 @@ class Window(Node):
 
 
 def Check(value):
-    return SQL('CHECK (%s)' % value)
+    return SQL('CHECK ({0!s})'.format(value))
 
 
 class DQ(Node):
@@ -1025,7 +1025,7 @@ class Field(Node):
         modifiers = self.get_modifiers()
         if modifiers:
             return SQL(
-                '%s(%s)' % (column_type, ', '.join(map(str, modifiers))))
+                '{0!s}({1!s})'.format(column_type, ', '.join(map(str, modifiers))))
         return SQL(column_type)
 
     def __ddl__(self, column_type):
@@ -1036,7 +1036,7 @@ class Field(Node):
         if self.primary_key:
             ddl.append(SQL('PRIMARY KEY'))
         if self.sequence:
-            ddl.append(SQL("DEFAULT NEXTVAL('%s')" % self.sequence))
+            ddl.append(SQL("DEFAULT NEXTVAL('{0!s}')".format(self.sequence)))
         if self.constraints:
             ddl.extend(self.constraints)
         return ddl
@@ -1083,7 +1083,7 @@ class _AutoPrimaryKeyField(PrimaryKeyField):
 
     def add_to_class(self, model_class, name):
         if name != self._column_name:
-            raise ValueError('%s must be named `%s`.' % (type(self), name))
+            raise ValueError('{0!s} must be named `{1!s}`.'.format(type(self), name))
         super(_AutoPrimaryKeyField, self).add_to_class(model_class, name)
 
 
@@ -1312,8 +1312,8 @@ class TimestampField(IntegerField):
     def __init__(self, *args, **kwargs):
         self.resolution = kwargs.pop('resolution', 1) or 1
         if self.resolution not in self.valid_resolutions:
-            raise ValueError('TimestampField resolution must be one of: %s' %
-                             ', '.join(str(i) for i in self.valid_resolutions))
+            raise ValueError('TimestampField resolution must be one of: {0!s}'.format(
+                             ', '.join(str(i) for i in self.valid_resolutions)))
 
         self.utc = kwargs.pop('utc', False) or False
         _dt = datetime.datetime
@@ -1473,7 +1473,7 @@ class ForeignKeyField(IntegerField):
     def _get_related_name(self):
         if self._related_name and callable(self._related_name):
             return self._related_name(self)
-        return self._related_name or ('%s_set' % self.model_class._meta.name)
+        return self._related_name or ('{0!s}_set'.format(self.model_class._meta.name))
 
     def add_to_class(self, model_class, name):
         if isinstance(self.rel_model, Proxy):
@@ -1489,7 +1489,7 @@ class ForeignKeyField(IntegerField):
 
         self.name = name
         self.model_class = model_class
-        self.db_column = obj_id_name = self.db_column or '%s_id' % self.name
+        self.db_column = obj_id_name = self.db_column or '{0!s}_id'.format(self.name)
         if obj_id_name == self.name:
             obj_id_name += '_id'
         if not self.verbose_name:
@@ -1511,7 +1511,7 @@ class ForeignKeyField(IntegerField):
         if model_class._meta.validate_backrefs:
             def invalid(msg, **context):
                 context.update(
-                    field='%s.%s' % (model_class._meta.name, name),
+                    field='{0!s}.{1!s}'.format(model_class._meta.name, name),
                     backref=self.related_name,
                     obj_id_name=obj_id_name)
                 raise AttributeError(msg % context)
@@ -1606,13 +1606,13 @@ class AliasMap(object):
         self._counter = start
 
     def __repr__(self):
-        return '<AliasMap: %s>' % self._alias_map
+        return '<AliasMap: {0!s}>'.format(self._alias_map)
 
     def add(self, obj, alias=None):
         if obj in self._alias_map:
             return
         self._counter += 1
-        self._alias_map[obj] = alias or '%s%s' % (self.prefix, self._counter)
+        self._alias_map[obj] = alias or '{0!s}{1!s}'.format(self.prefix, self._counter)
 
     def __getitem__(self, obj):
         if obj not in self._alias_map:
@@ -1718,7 +1718,7 @@ class QueryCompiler(object):
         }
 
     def quote(self, s):
-        return '%s%s%s' % (self.quote_char, s, self.quote_char)
+        return '{0!s}{1!s}{2!s}'.format(self.quote_char, s, self.quote_char)
 
     def get_column_type(self, f):
         return self._field_map[f] if f in self._field_map else f.upper()
@@ -1761,13 +1761,13 @@ class QueryCompiler(object):
     def _parse_func(self, node, alias_map, conv):
         conv = node._coerce and conv or None
         sql, params = self.parse_node_list(node.arguments, alias_map, conv)
-        return '%s(%s)' % (node.name, strip_parens(sql)), params
+        return '{0!s}({1!s})'.format(node.name, strip_parens(sql)), params
 
     def _parse_clause(self, node, alias_map, conv):
         sql, params = self.parse_node_list(
             node.nodes, alias_map, conv, node.glue)
         if node.parens:
-            sql = '(%s)' % strip_parens(sql)
+            sql = '({0!s})'.format(strip_parens(sql))
         return sql, params
 
     def _parse_entity(self, node, alias_map, conv):
@@ -1811,9 +1811,9 @@ class QueryCompiler(object):
         # We add outer parentheses in the event the compound query is used in
         # the `from_()` clause, in which case we'll need them.
         if node.database.compound_select_parentheses:
-            sql = '((%s) %s (%s))' % (l, node.operator, r)
+            sql = '(({0!s}) {1!s} ({2!s}))'.format(l, node.operator, r)
         else:
-            sql = '(%s %s %s)' % (l, node.operator, r)
+            sql = '({0!s} {1!s} {2!s})'.format(l, node.operator, r)
         return sql, lp + rp
 
     def _parse_select_query(self, node, alias_map, conv):
@@ -1825,7 +1825,7 @@ class QueryCompiler(object):
                 select_field = clone.model_class._meta.primary_key
             clone._select = (select_field,)
         sub, params = self.generate_select(clone, alias_map)
-        return '(%s)' % strip_parens(sub), params
+        return '({0!s})'.format(strip_parens(sub)), params
 
     def _parse_strip_parens(self, node, alias_map, conv):
         sql, params = self.parse_node(node.node, alias_map, conv)
@@ -1845,7 +1845,7 @@ class QueryCompiler(object):
             # If you're wondering how to pass a list into your query, simply
             # wrap it in Param().
             sql, params = self.parse_node_list(node, alias_map, conv)
-            sql = '(%s)' % sql
+            sql = '({0!s})'.format(sql)
         elif isinstance(node, Model):
             sql = self.interpolation
             if conv and isinstance(conv, ForeignKeyField):
@@ -1877,7 +1877,7 @@ class QueryCompiler(object):
 
         if isinstance(node, Node):
             if node._negated:
-                sql = 'NOT %s' % sql
+                sql = 'NOT {0!s}'.format(sql)
             if node._alias:
                 sql = ' '.join((sql, 'AS', node._alias))
             if node._ordering:
@@ -2025,9 +2025,9 @@ class QueryCompiler(object):
 
         if query._limit is not None or (query._offset and db.limit_max):
             limit = query._limit if query._limit is not None else db.limit_max
-            clauses.append(SQL('LIMIT %s' % limit))
+            clauses.append(SQL('LIMIT {0!s}'.format(limit)))
         if query._offset is not None:
-            clauses.append(SQL('OFFSET %s' % query._offset))
+            clauses.append(SQL('OFFSET {0!s}'.format(query._offset)))
 
         for_update, no_wait = query._for_update
         if for_update:
@@ -2041,7 +2041,7 @@ class QueryCompiler(object):
         alias_map = self.alias_map_class()
         alias_map.add(model, model._meta.db_table)
         if query._on_conflict:
-            statement = 'UPDATE OR %s' % query._on_conflict
+            statement = 'UPDATE OR {0!s}'.format(query._on_conflict)
         else:
             statement = 'UPDATE'
         clauses = [SQL(statement), model.as_entity(), SQL('SET')]
@@ -2079,7 +2079,7 @@ class QueryCompiler(object):
         if query._upsert:
             statement = meta.database.upsert_sql
         elif query._on_conflict:
-            statement = 'INSERT OR %s INTO' % query._on_conflict
+            statement = 'INSERT OR {0!s} INTO'.format(query._on_conflict)
         else:
             statement = 'INSERT INTO'
         clauses = [SQL(statement), model.as_entity()]
@@ -2156,9 +2156,9 @@ class QueryCompiler(object):
             field.rel_model.as_entity(),
             EnclosedClause(field.to_field.as_entity())]
         if field.on_delete:
-            ddl.append(SQL('ON DELETE %s' % field.on_delete))
+            ddl.append(SQL('ON DELETE {0!s}'.format(field.on_delete)))
         if field.on_update:
-            ddl.append(SQL('ON UPDATE %s' % field.on_update))
+            ddl.append(SQL('ON UPDATE {0!s}'.format(field.on_update)))
         return Clause(*ddl)
 
     def return_parsed_node(function_name):
@@ -2171,7 +2171,7 @@ class QueryCompiler(object):
         return inner
 
     def _create_foreign_key(self, model_class, field, constraint=None):
-        constraint = constraint or 'fk_%s_%s_refs_%s' % (
+        constraint = constraint or 'fk_{0!s}_{1!s}_refs_{2!s}'.format(
             model_class._meta.db_table,
             field.db_column,
             field.rel_model._meta.db_table)
@@ -2234,10 +2234,10 @@ class QueryCompiler(object):
     truncate_table = return_parsed_node('_truncate_table')
 
     def index_name(self, table, columns):
-        index = '%s_%s' % (table, '_'.join(columns))
+        index = '{0!s}_{1!s}'.format(table, '_'.join(columns))
         if len(index) > 64:
             index_hash = hashlib.md5(index.encode('utf-8')).hexdigest()
-            index = '%s_%s' % (table[:55], index_hash[:8])  # 55 + 1 + 8 = 64
+            index = '{0!s}_{1!s}'.format(table[:55], index_hash[:8])  # 55 + 1 + 8 = 64
         return index
 
     def _create_index(self, model_class, fields, unique, *extra):
@@ -2791,7 +2791,7 @@ class Query(Node):
 
     def __repr__(self):
         sql, params = self.sql()
-        return '%s %s %s' % (self.model_class, sql, params)
+        return '{0!s} {1!s} {2!s}'.format(self.model_class, sql, params)
 
     def clone(self):
         query = type(self)(self.model_class)
@@ -3067,7 +3067,7 @@ class SelectQuery(Query):
             supported_ops = self.model_class._meta.database.compound_operations
             if operator not in supported_ops:
                 raise ValueError(
-                    'Your database does not support %s' % operator)
+                    'Your database does not support {0!s}'.format(operator))
             return CompoundSelect(self.model_class, self, operator, other)
 
         return inner
@@ -3192,7 +3192,7 @@ class SelectQuery(Query):
             clone._limit = clone._offset = None
 
         sql, params = clone.sql()
-        wrapped = 'SELECT COUNT(1) FROM (%s) AS wrapped_select' % sql
+        wrapped = 'SELECT COUNT(1) FROM ({0!s}) AS wrapped_select'.format(sql)
         rq = self.model_class.raw(wrapped, *params)
         return rq.scalar() or 0
 
@@ -3207,8 +3207,7 @@ class SelectQuery(Query):
             return next(clone.execute())
         except StopIteration:
             raise self.model_class.DoesNotExist(
-                'Instance matching query does not exist:\nSQL: %s\nPARAMS: %s'
-                % self.sql())
+                'Instance matching query does not exist:\nSQL: {0!s}\nPARAMS: {1!s}'.format(*self.sql()))
 
     def peek(self, n=1):
         res = self.execute()
@@ -3465,7 +3464,7 @@ class InsertQuery(_WriteQuery):
 
             def validate_field(field):
                 if field not in valid_fields:
-                    raise KeyError('"%s" is not a recognized field.' % field)
+                    raise KeyError('"{0!s}" is not a recognized field.'.format(field))
 
         defaults = model_meta._default_dict
         callables = model_meta._default_callables
@@ -4028,11 +4027,11 @@ class SqliteDatabase(Database):
         if self._pragmas:
             cursor = conn.cursor()
             for pragma, value in self._pragmas:
-                cursor.execute('PRAGMA %s = %s;' % (pragma, value))
+                cursor.execute('PRAGMA {0!s} = {1!s};'.format(pragma, value))
             cursor.close()
 
     def begin(self, lock_type='DEFERRED'):
-        self.execute_sql('BEGIN %s' % lock_type, require_commit=False)
+        self.execute_sql('BEGIN {0!s}'.format(lock_type), require_commit=False)
 
     def create_foreign_key(self, model_class, field, constraint=None):
         raise OperationalError('SQLite does not support ALTER TABLE '
@@ -4051,7 +4050,7 @@ class SqliteDatabase(Database):
 
         # Determine which indexes have a unique constraint.
         unique_indexes = set()
-        cursor = self.execute_sql('PRAGMA index_list("%s")' % table)
+        cursor = self.execute_sql('PRAGMA index_list("{0!s}")'.format(table))
         for row in cursor.fetchall():
             name = row[1]
             is_unique = int(row[2]) == 1
@@ -4061,7 +4060,7 @@ class SqliteDatabase(Database):
         # Retrieve the indexed columns.
         index_columns = {}
         for index_name in sorted(index_to_sql):
-            cursor = self.execute_sql('PRAGMA index_info("%s")' % index_name)
+            cursor = self.execute_sql('PRAGMA index_info("{0!s}")'.format(index_name))
             index_columns[index_name] = [row[2] for row in cursor.fetchall()]
 
         return [
@@ -4074,16 +4073,16 @@ class SqliteDatabase(Database):
             for name in sorted(index_to_sql)]
 
     def get_columns(self, table, schema=None):
-        cursor = self.execute_sql('PRAGMA table_info("%s")' % table)
+        cursor = self.execute_sql('PRAGMA table_info("{0!s}")'.format(table))
         return [ColumnMetadata(row[1], row[2], not row[3], bool(row[5]), table)
                 for row in cursor.fetchall()]
 
     def get_primary_keys(self, table, schema=None):
-        cursor = self.execute_sql('PRAGMA table_info("%s")' % table)
+        cursor = self.execute_sql('PRAGMA table_info("{0!s}")'.format(table))
         return [row[1] for row in cursor.fetchall() if row[-1]]
 
     def get_foreign_keys(self, table, schema=None):
-        cursor = self.execute_sql('PRAGMA foreign_key_list("%s")' % table)
+        cursor = self.execute_sql('PRAGMA foreign_key_list("{0!s}")'.format(table))
         return [ForeignKeyMetadata(row[3], row[2], row[4], table)
                 for row in cursor.fetchall()]
 
@@ -4144,7 +4143,7 @@ class PostgresqlDatabase(Database):
         if meta.primary_key is not False and meta.primary_key.sequence:
             return meta.primary_key.sequence
         elif meta.auto_increment:
-            return '%s_%s_seq' % (meta.db_table, meta.primary_key.db_column)
+            return '{0!s}_{1!s}_seq'.format(meta.db_table, meta.primary_key.db_column)
 
     def last_insert_id(self, cursor, model):
         sequence = self._get_pk_sequence(model)
@@ -4153,11 +4152,11 @@ class PostgresqlDatabase(Database):
 
         meta = model._meta
         if meta.schema:
-            schema = '%s.' % meta.schema
+            schema = '{0!s}.'.format(meta.schema)
         else:
             schema = ''
 
-        cursor.execute("SELECT CURRVAL('%s\"%s\"')" % (schema, sequence))
+        cursor.execute("SELECT CURRVAL('{0!s}\"{1!s}\"')".format(schema, sequence))
         result = cursor.fetchone()[0]
         if self.get_autocommit():
             self.commit()
@@ -4242,7 +4241,7 @@ class PostgresqlDatabase(Database):
 
     def set_search_path(self, *search_path):
         path_params = ','.join(['%s'] * len(search_path))
-        self.execute_sql('SET search_path TO %s' % path_params, search_path)
+        self.execute_sql('SET search_path TO {0!s}'.format(path_params), search_path)
 
     def get_noop_sql(self):
         return 'SELECT 0 WHERE false'
@@ -4291,7 +4290,7 @@ class MySQLDatabase(Database):
         return [row for row, in self.execute_sql('SHOW TABLES')]
 
     def get_indexes(self, table, schema=None):
-        cursor = self.execute_sql('SHOW INDEX FROM `%s`' % table)
+        cursor = self.execute_sql('SHOW INDEX FROM `{0!s}`'.format(table))
         unique = set()
         indexes = {}
         for row in cursor.fetchall():
@@ -4313,7 +4312,7 @@ class MySQLDatabase(Database):
                 for name, null, dt in cursor.fetchall()]
 
     def get_primary_keys(self, table, schema=None):
-        cursor = self.execute_sql('SHOW INDEX FROM `%s`' % table)
+        cursor = self.execute_sql('SHOW INDEX FROM `{0!s}`'.format(table))
         return [row[4] for row in cursor.fetchall() if row[2] == 'PRIMARY']
 
     def get_foreign_keys(self, table, schema=None):
@@ -4473,15 +4472,15 @@ class savepoint(_callable_context_manager):
         self.db.execute_sql(query, require_commit=False)
 
     def commit(self):
-        self._execute('RELEASE SAVEPOINT %s;' % self.quoted_sid)
+        self._execute('RELEASE SAVEPOINT {0!s};'.format(self.quoted_sid))
 
     def rollback(self):
-        self._execute('ROLLBACK TO SAVEPOINT %s;' % self.quoted_sid)
+        self._execute('ROLLBACK TO SAVEPOINT {0!s};'.format(self.quoted_sid))
 
     def __enter__(self):
         self._orig_autocommit = self.db.get_autocommit()
         self.db.set_autocommit(False)
-        self._execute('SAVEPOINT %s;' % self.quoted_sid)
+        self._execute('SAVEPOINT {0!s};'.format(self.quoted_sid))
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -4663,7 +4662,7 @@ class ModelOptions(object):
             self.db_table = self.db_table_func(cls)
 
     def __repr__(self):
-        return '<%s: %s>' % (self.__class__.__name__, self.name)
+        return '<{0!s}: {1!s}>'.format(self.__class__.__name__, self.name)
 
     def prepared(self):
         if self.order_by:
@@ -4868,10 +4867,10 @@ class BaseModel(type):
 
         # create a repr and error class before finalizing
         if hasattr(cls, '__unicode__'):
-            setattr(cls, '__repr__', lambda self: '<%s: %r>' % (
+            setattr(cls, '__repr__', lambda self: '<{0!s}: {1!r}>'.format(
                 cls.__name__, self.__unicode__()))
 
-        exc_name = '%sDoesNotExist' % cls.__name__
+        exc_name = '{0!s}DoesNotExist'.format(cls.__name__)
         exc_attrs = {'__module__': cls.__module__}
         exception_class = type(exc_name, (DoesNotExist,), exc_attrs)
         cls.DoesNotExist = exception_class
@@ -5244,7 +5243,7 @@ def prefetch_add_subquery(sq, subqueries):
                 break
 
         if not (fks or backrefs):
-            tgt_err = ' using %s' % target_model if target_model else ''
+            tgt_err = ' using {0!s}'.format(target_model) if target_model else ''
             raise AttributeError('Error: unable to find foreign key for '
                                  'query: %s%s' % (subquery, tgt_err))
 
@@ -5297,7 +5296,7 @@ class PrefetchResult(__prefetched):
                 identifier = instance._data[field.to_field.name]
                 key = (field, identifier)
                 rel_instances = id_map.get(key, [])
-                dest = '%s_prefetch' % field.related_name
+                dest = '{0!s}_prefetch'.format(field.related_name)
                 for inst in rel_instances:
                     setattr(inst, attname, instance)
                 setattr(instance, dest, rel_instances)

--- a/tests/base.py
+++ b/tests/base.py
@@ -65,14 +65,14 @@ class DatabaseInitializer(object):
         try:
             return mapping[backend]
         except KeyError:
-            print_('Unrecognized database: "%s".' % backend)
-            print_('Available choices:\n%s' % '\n'.join(
-                sorted(mapping.keys())))
+            print_('Unrecognized database: "{0!s}".'.format(backend))
+            print_('Available choices:\n{0!s}'.format('\n'.join(
+                sorted(mapping.keys()))))
             raise
 
     def get_database(self, backend=None, db_class=None, **kwargs):
         backend = backend or self.backend
-        method = 'get_%s_database' % backend
+        method = 'get_{0!s}_database'.format(backend)
         kwargs.setdefault('use_speedups', False)
 
         if db_class is None:
@@ -84,7 +84,7 @@ class DatabaseInitializer(object):
             return getattr(self, method)(db_class, **kwargs)
 
     def get_filename(self, extension):
-        return os.path.join('/tmp', '%s%s' % (self.database_name, extension))
+        return os.path.join('/tmp', '{0!s}{1!s}'.format(self.database_name, extension))
 
     def get_apsw_database(self, db_class, **kwargs):
         return db_class(self.get_filename('.db'), timeout=1000, **kwargs)
@@ -170,7 +170,7 @@ class PeeweeTestCase(TestCase):
         logger.removeHandler(self.qh)
 
     def assertIsNone(self, value):
-        assert value is None, '%r is not None' % value
+        assert value is None, '{0!r} is not None'.format(value)
 
     def assertIsNotNone(self, value):
         assert value is not None
@@ -182,7 +182,7 @@ class PeeweeTestCase(TestCase):
         except exc_class:
             return
         else:
-            raise AssertionError('Exception %s not raised.' % exc_class)
+            raise AssertionError('Exception {0!s} not raised.'.format(exc_class))
 
     def queries(self, ignore_txn=False):
         queries = [x.msg for x in self.qh.queries]
@@ -257,7 +257,7 @@ def skip_if(expression):
     def decorator(klass):
         if expression():
             if TEST_VERBOSITY > 0:
-                print_('Skipping %s tests.' % klass.__name__)
+                print_('Skipping {0!s} tests.'.format(klass.__name__))
 
             class Dummy(object):
                 pass
@@ -280,7 +280,7 @@ def skip_test_if(expression):
         def inner(*args, **kwargs):
             if expression():
                 if TEST_VERBOSITY > 1:
-                    print_('Skipping %s test.' % fn.__name__)
+                    print_('Skipping {0!s} test.'.format(fn.__name__))
             else:
                 return fn(*args, **kwargs)
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -101,7 +101,7 @@ class User(TestModel):
     @classmethod
     def create_users(cls, n):
         for i in range(n):
-            cls.create(username='u%d' % (i + 1))
+            cls.create(username='u{0:d}'.format((i + 1)))
 
 
 class Blog(TestModel):
@@ -112,7 +112,7 @@ class Blog(TestModel):
     pk = PrimaryKeyField()
 
     def __unicode__(self):
-        return '%s: %s' % (self.user.username, self.title)
+        return '{0!s}: {1!s}'.format(self.user.username, self.title)
 
     def prepared(self):
         self.foo = self.title

--- a/tests/test_compound_queries.py
+++ b/tests/test_compound_queries.py
@@ -221,8 +221,7 @@ class TestCompoundSelectQueries(ModelTestCase):
                 if op in test_db.compound_operations:
                     return fn(self)
                 else:
-                    log_console('"%s" not supported, skipping %s' %
-                                (op, fn.__name__))
+                    log_console('"{0!s}" not supported, skipping {1!s}'.format(op, fn.__name__))
 
             return inner
 
@@ -380,7 +379,7 @@ class TestCompoundSelectQueries(ModelTestCase):
         users = User.select().order_by(User.username)
         for user in users:
             for msg in ['foo', 'bar', 'baz']:
-                Blog.create(title='%s-%s' % (user.username, msg), user=user)
+                Blog.create(title='{0!s}-{1!s}'.format(user.username, msg), user=user)
 
         with self.assertQueryCount(1):
             q1 = (Blog

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -45,7 +45,7 @@ class TestMultiThreadedQueries(ModelTestCase):
     def test_multiple_writers(self):
         def create_user_thread(low, hi):
             for i in range(low, hi):
-                User.create(username='u%d' % i)
+                User.create(username='u{0:d}'.format(i))
             User._meta.database.close()
 
         threads = []
@@ -197,7 +197,7 @@ class TestDroppingIndex(ModelTestCase):
 
         assert sorted(query_log.queries) == sorted([
                                                        (
-                                                           'DROP INDEX "%s"' % idx.name,
+                                                           'DROP INDEX "{0!s}"'.format(idx.name),
                                                            []) for idx in
                                                        indexes])
         assert db.get_indexes(IndexedModel._meta.db_table) == []
@@ -329,7 +329,7 @@ class TestOuterLoopInnerCommit(ModelTestCase):
             User.create(username=username)
 
         for user in User.select():
-            Blog.create(user=user, title='b-%s' % user.username)
+            Blog.create(user=user, title='b-{0!s}'.format(user.username))
 
         # These statements are auto-committed.
         new_db = self.new_connection()
@@ -347,7 +347,7 @@ class TestOuterLoopInnerCommit(ModelTestCase):
         test_db.begin()
 
         for user in User.select():
-            Blog.create(user=user, title='b-%s' % user.username)
+            Blog.create(user=user, title='b-{0!s}'.format(user.username))
 
         # These statements have not been committed.
         new_db = self.new_connection()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -110,7 +110,7 @@ class TestFieldTypes(ModelTestCase):
             like_wildcard = '*'
         else:
             like_wildcard = '%'
-        like_str = '%sA%s' % (like_wildcard, like_wildcard)
+        like_str = '{0!s}A{1!s}'.format(like_wildcard, like_wildcard)
         ilike_str = '%A%'
 
         case_sens = NM.select(NM.char_field).where(NM.char_field % like_str)

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -24,7 +24,7 @@ class TestForeignKeyToNonPrimaryKey(ModelTestCase):
             for i in range(2):
                 PackageItem.create(
                     package=barcode,
-                    title='%s-%s' % (barcode, i))
+                    title='{0!s}-{1!s}'.format(barcode, i))
 
     def test_fk_resolution(self):
         pi = PackageItem.get(PackageItem.title == '101-0')
@@ -174,8 +174,8 @@ class TestCompositePrimaryKey(ModelTestCase):
 
     def setUp(self):
         super(TestCompositePrimaryKey, self).setUp()
-        tags = [Tag.create(tag='t%d' % i) for i in range(1, 4)]
-        posts = [Post.create(title='p%d' % i) for i in range(1, 4)]
+        tags = [Tag.create(tag='t{0:d}'.format(i)) for i in range(1, 4)]
+        posts = [Post.create(title='p{0:d}'.format(i)) for i in range(1, 4)]
         p12 = Post.create(title='p12')
         for t, p in zip(tags, posts):
             TagPostThrough.create(tag=t, post=p)
@@ -282,7 +282,7 @@ class TestCompositePrimaryKey(ModelTestCase):
             (CKM.f2 == 3)).exists()
 
     def test_delete_instance(self):
-        u1, u2 = [User.create(username='u%s' % i) for i in range(2)]
+        u1, u2 = [User.create(username='u{0!s}'.format(i)) for i in range(2)]
         ut1 = UserThing.create(thing='t1', user=u1)
         ut2 = UserThing.create(thing='t2', user=u1)
         ut3 = UserThing.create(thing='t1', user=u2)
@@ -442,7 +442,7 @@ class TestForeignKeyConstraints(ModelTestCase):
             return
 
         state = 'on' if is_enabled else 'off'
-        test_db.execute_sql('PRAGMA foreign_keys = %s' % state)
+        test_db.execute_sql('PRAGMA foreign_keys = {0!s}'.format(state))
 
     def test_constraint_exists(self):
         # IntegrityError is raised when we specify a non-existent user_id.

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1214,7 +1214,7 @@ class TestInsertQuery(PeeweeTestCase):
     def test_insert_many_gen(self):
         def row_generator():
             for i in range(3):
-                yield {'username': 'u%s' % i}
+                yield {'username': 'u{0!s}'.format(i)}
 
         iq = InsertQuery(User, rows=row_generator())
         assert compiler.generate_insert(iq) == (
@@ -1383,7 +1383,7 @@ class TestInsertReturning(PeeweeTestCase):
         class User(self.BaseModel):
             username = CharField()
 
-        data = [{'username': 'user-%s' % i} for i in range(3)]
+        data = [{'username': 'user-{0!s}'.format(i)} for i in range(3)]
         # Bulk inserts do not ask for returned primary keys.
         self.assertInsertSQL(
             User.insert_many(data),
@@ -2016,9 +2016,9 @@ class TestDistinctOn(ModelTestCase):
 
     def test_distinct_on(self):
         for i in range(1, 4):
-            u = User.create(username='u%s' % i)
+            u = User.create(username='u{0!s}'.format(i))
             for j in range(i):
-                Blog.create(user=u, title='b-%s-%s' % (i, j))
+                Blog.create(user=u, title='b-{0!s}-{1!s}'.format(i, j))
 
         query = (Blog
                  .select(User.username, Blog.title)
@@ -2074,7 +2074,7 @@ class TestForUpdate(ModelTestCase):
 
         # select the username, it will not register as being updated
         res = new_db.execute_sql(
-            'select username from users where id = %s;' % u1.id)
+            'select username from users where id = {0!s};'.format(u1.id))
         username = res.fetchone()[0]
         assert username == 'u1'
 
@@ -2083,7 +2083,7 @@ class TestForUpdate(ModelTestCase):
 
         # now we get the update
         res = new_db.execute_sql(
-            'select username from users where id = %s;' % u1.id)
+            'select username from users where id = {0!s};'.format(u1.id))
         username = res.fetchone()[0]
         assert username == 'u1_edited'
 

--- a/tests/test_query_results.py
+++ b/tests/test_query_results.py
@@ -37,10 +37,10 @@ class TestQueryResultWrapper(ModelTestCase):
             assert names(sq[2:5]) == ['u3', 'u4', 'u5']
 
             another_iter = names(qr)
-            assert another_iter == ['u%d' % i for i in range(1, 11)]
+            assert another_iter == ['u{0:d}'.format(i) for i in range(1, 11)]
 
             another_iter = names(qr)
-            assert another_iter == ['u%d' % i for i in range(1, 11)]
+            assert another_iter == ['u{0:d}'.format(i) for i in range(1, 11)]
 
     def test_count(self):
         User.create_users(5)
@@ -118,7 +118,7 @@ class TestQueryResultWrapper(ModelTestCase):
         with self.assertQueryCount(1):
             qr = User.select().order_by(User.id).execute()
             usernames = [u.username for u in qr.iterator()]
-            assert usernames == ['u%d' % i for i in range(1, 11)]
+            assert usernames == ['u{0:d}'.format(i) for i in range(1, 11)]
 
         assert qr._populated
         assert qr._result_cache == []
@@ -138,7 +138,7 @@ class TestQueryResultWrapper(ModelTestCase):
         with self.assertQueryCount(1):
             qr = User.select().order_by(User.id)
             usernames = [u.username for u in qr.iterator()]
-            assert usernames == ['u%d' % i for i in range(1, 11)]
+            assert usernames == ['u{0:d}'.format(i) for i in range(1, 11)]
 
         with self.assertQueryCount(0):
             again = [u.username for u in qr]
@@ -149,8 +149,8 @@ class TestQueryResultWrapper(ModelTestCase):
         for i in range(1, 4):
             for j in range(i):
                 Blog.create(
-                    title='blog-%s-%s' % (i, j),
-                    user=User.get(User.username == 'u%s' % i))
+                    title='blog-{0!s}-{1!s}'.format(i, j),
+                    user=User.get(User.username == 'u{0!s}'.format(i)))
 
         qr = (User
               .select(
@@ -187,7 +187,7 @@ class TestQueryResultWrapper(ModelTestCase):
     def test_fill_cache(self):
         def assertUsernames(qr, n):
             assert [u.username for u in qr._result_cache] == \
-                   ['u%d' % i for i in range(1, n + 1)]
+                   ['u{0:d}'.format(i) for i in range(1, n + 1)]
 
         User.create_users(20)
 
@@ -335,7 +335,7 @@ class TestQueryResultWrapper(ModelTestCase):
     def test_slicing_dicing(self):
         def assertUsernames(users, nums):
             assert [u.username for u in users] == \
-                   ['u%d' % i for i in nums]
+                   ['u{0:d}'.format(i) for i in nums]
 
         User.create_users(10)
 
@@ -410,7 +410,7 @@ class TestQueryResultWrapper(ModelTestCase):
 
     def test_indexing_fill_cache(self):
         def assertUser(query_or_qr, idx):
-            assert query_or_qr[idx].username == 'u%d' % (idx + 1)
+            assert query_or_qr[idx].username == 'u{0:d}'.format((idx + 1))
 
         User.create_users(10)
         uq = User.select().order_by(User.id)
@@ -442,9 +442,9 @@ class TestQueryResultWrapper(ModelTestCase):
 
     def test_prepared(self):
         for i in range(2):
-            u = User.create(username='u%d' % i)
+            u = User.create(username='u{0:d}'.format(i))
             for j in range(2):
-                Blog.create(title='b%d-%d' % (i, j), user=u, content='')
+                Blog.create(title='b{0:d}-{1:d}'.format(i, j), user=u, content='')
 
         for u in User.select():
             # check prepared was called
@@ -627,7 +627,7 @@ class TestJoinedInstanceConstruction(ModelTestCase):
     def test_multiple_joins(self):
         Blog.delete().execute()
         User.delete().execute()
-        users = [User.create(username='u%s' % i) for i in range(4)]
+        users = [User.create(username='u{0!s}'.format(i)) for i in range(4)]
         for from_user, to_user in itertools.combinations(users, 2):
             Relationship.create(from_user=from_user, to_user=to_user)
 
@@ -680,7 +680,7 @@ class TestQueryResultTypeConversion(ModelTestCase):
     def setUp(self):
         super(TestQueryResultTypeConversion, self).setUp()
         for i in range(3):
-            User.create(username='u%d' % i)
+            User.create(username='u{0:d}'.format(i))
 
     def assertNames(self, query, expected, attr='username'):
         id_field = query.model_class.id
@@ -804,7 +804,7 @@ class TestModelQueryResultWrapper(ModelTestCase):
         u1 = User.create(username='u1')
         u2 = User.create(username='u2')
         for user in (u1, u2):
-            Blog.create(title='b-%s' % user.username, user=user)
+            Blog.create(title='b-{0!s}'.format(user.username), user=user)
 
         # Create an additional blog for user 2.
         Blog.create(title='b-u2-2', user=u2)
@@ -1033,7 +1033,7 @@ class BaseTestPrefetch(ModelTestCase):
         p2 = cc('p2', root)
         for p in (p1, p2):
             for i in range(2):
-                cc('%s-%s' % (p.name, i + 1), p)
+                cc('{0!s}-{1!s}'.format(p.name, i + 1), p)
 
 
 class TestPrefetch(BaseTestPrefetch):
@@ -1197,11 +1197,11 @@ class TestPrefetch(BaseTestPrefetch):
         u2 = User.create(username='u2')
         for i in range(1, 3):
             for user in (u1, u2):
-                b = Blog.create(user=user, title='%s-b%s' % (user.username, i))
+                b = Blog.create(user=user, title='{0!s}-b{1!s}'.format(user.username, i))
                 SpecialComment.create(
                     user=user,
                     blog=b,
-                    name='%s-c%s' % (user.username, i))
+                    name='{0!s}-c{1!s}'.format(user.username, i))
 
         u3 = User.create(username='u3')
         SpecialComment.create(user=u3, name='u3-c1')
@@ -1886,7 +1886,7 @@ class TestAggregateRowsRegression(ModelTestCase):
     def test_regression_506(self):
         user = User.create(username='u2')
         for i in range(2):
-            Blog.create(title='u2-%s' % i, user=user)
+            Blog.create(title='u2-{0!s}'.format(i), user=user)
 
         users = (User
                  .select()

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -292,7 +292,7 @@ class TestExecutionContext(ModelTestCase):
         def create(i):
             with test_db.execution_context():
                 with test_db.execution_context() as ctx:
-                    User.create(username='u%s' % i)
+                    User.create(username='u{0!s}'.format(i))
                     assert ctx.database.execution_context_depth() == 2
 
         threads = [threading.Thread(target=create, args=(i,))
@@ -563,7 +563,7 @@ class TestAtomic(ModelTestCase):
 
     def test_atomic_with_delete(self):
         for i in range(3):
-            User.create(username='u%s' % i)
+            User.create(username='u{0!s}'.format(i))
 
         with test_db.atomic():
             User.get(User.username == 'u1').delete_instance()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:vmuriart:peewee?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:vmuriart:peewee?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
